### PR TITLE
update schema.graphql

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -32,6 +32,6 @@ type Subscription {
     @aws_subscribe(mutations: ["createPost"])
   onUpdatePost: Post
     @aws_subscribe(mutations: ["updatePost"])
-  onDeletePost: Post
+  onDeletePost: String
     @aws_subscribe(mutations: ["deletePost"])
 }


### PR DESCRIPTION
I was receiving AppSync error `The subscription has an invalid output type.` I believe because the mutation says `deletePost` returns a string but the subscription previously said a `Post`.